### PR TITLE
change formatting of FormattedLogValues and AdditionalValues

### DIFF
--- a/Daenet.Common.Logging.EventHub/EventHubLogger.cs
+++ b/Daenet.Common.Logging.EventHub/EventHubLogger.cs
@@ -131,21 +131,22 @@ namespace Daenet.Common.Logging.EventHub
                 StackTrace = exception.StackTrace
             });
 
-            if (this.m_AdditionalValues != null)
+            if (m_AdditionalValues != null && m_AdditionalValues.Count > 0)
             {
-                foreach (var item in this.m_AdditionalValues)
-                {
-                    data.Add(item.Key, item.Value);
-                }
+                data.Add("AdditionalValues", m_AdditionalValues);
             }
 
             if (state is FormattedLogValues)
             {
-                FormattedLogValues v = state as FormattedLogValues;
-                foreach (var item in v)
+                FormattedLogValues values = (FormattedLogValues)state;
+
+                var formattedLogValues = new Dictionary<string, object>();
+                foreach (var item in values)
                 {
-                    data.Add(item.Key, item.Value);
+                    formattedLogValues.Add(item.Key, item.Value);
                 }
+
+                data.Add("FormattedLogValues", formattedLogValues);
             }
 
             var payload = JsonConvert.SerializeObject(data);


### PR DESCRIPTION
This commit changes formatting of FormattedLogValues and AdditionalValues.

When running the `LogWithAdditionalData` test EventHubLogger will send this json message to eventhub:

````json
{
   "Name":"Daenet.Common.Logging.EventHub.UnitTests.EventHubLoggerUnitTests",
   "Scope":null,
   "EventId":"0",
   "Message":"1, Test 2 Log Message",
   "Level":0,
   "LocalEnqueuedTime":"2017-07-11T14:38:06.1385912+02:00",
   "Exception":null,
   "AdditionalValues":{
      "HOSTNAME":"HostName",
      "SomeInt":42
   },
   "FormattedLogValues":{
      "PRM1":1,
      "PRM2":"2",
      "{OriginalFormat}":"{PRM1}, Test {PRM2} Log Message"
   }
}
````

instead of this:

````json
{
   "Name":"Daenet.Common.Logging.EventHub.UnitTests.EventHubLoggerUnitTests",
   "Scope":null,
   "EventId":"0",
   "Message":"1, Test 2 Log Message",
   "Level":0,
   "LocalEnqueuedTime":"2017-07-11T14:39:30.4518728+02:00",
   "Exception":null,
   "HOSTNAME":"HostName",
   "SomeInt":42,
   "PRM1":1,
   "PRM2":"2",
   "{OriginalFormat}":"{PRM1}, Test {PRM2} Log Message"
}
````


This changes helps to make clear what is *AdditionalData* and what are the *FormattedLogValues*.

It also fixes DuplicateKeyExceptions when using for example "Exception" as key for *AdditionalData*.